### PR TITLE
fix: missing response types

### DIFF
--- a/src/monday_sdk/types/api_response_types.py
+++ b/src/monday_sdk/types/api_response_types.py
@@ -6,6 +6,7 @@ from typing import Optional, List
 class Column:
     id: Optional[str] = field(default=None)
     title: Optional[str] = field(default=None)
+    type: Optional[str] = field(default=None)
 
 
 @dataclass
@@ -80,10 +81,13 @@ class ActivityLog:
 
 @dataclass
 class Board:
+    id: Optional[str] = field(default=None)
     name: Optional[str] = field(default=None)
     items_page: Optional[ItemsPage] = field(default=None)
     updates: Optional[List[Update]] = field(default_factory=list)
     activity_logs: Optional[List[ActivityLog]] = field(default_factory=list)
+    columns: Optional[List[Column]] = field(default_factory=list)
+    groups: Optional[List[Group]] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
This fix addresses missing response types in the `Board` dataclass within `src/monday_sdk/types/api_response_types.py`.

Previously, the `Board` object lacked definitions for its `columns` and `groups` attributes. This omission prevented the `fetch_columns` and `fetch_groups` API calls from properly returning their respective outputs, as both operations require a `board_id` and are intrinsically linked to the `Board` structure.

This change introduces:

* A `type` field to the `Column` dataclass for better type representation.
* `id` and `name` fields to the `Board` dataclass for more complete `Board` information.
* `columns` and `groups` fields (as lists of `Column` and `Group` objects, respectively) to the `Board` dataclass.
