### PR TITLE
Add MondayClient init type hints

### DIFF
--- a/src/monday_sdk/client.py
+++ b/src/monday_sdk/client.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional
+
 from .modules import BoardModule, ItemModule, UpdateModule, CustomModule, ActivityLogModule, DocsModule
 from .constants import API_VERSION, DEFAULT_MAX_RETRY_ATTEMPTS
 from .graphql_handler import MondayGraphQL
@@ -6,15 +8,21 @@ BASE_HEADERS = {"API-Version": API_VERSION}
 
 
 class MondayClient:
-    def __init__(self, token, headers=None, debug_mode=False, max_retry_attempts=DEFAULT_MAX_RETRY_ATTEMPTS):
+    def __init__(
+        self,
+        token: str,
+        headers: Optional[Dict[str, str]] = None,
+        debug_mode: bool = False,
+        max_retry_attempts: int = DEFAULT_MAX_RETRY_ATTEMPTS,
+    ) -> None:
         headers = headers or BASE_HEADERS.copy()
-        
+
         # Create a single GraphQL client instance
         self._graphql_client = MondayGraphQL(
             token=token,
             headers=headers,
             debug_mode=debug_mode,
-            max_retry_attempts=max_retry_attempts
+            max_retry_attempts=max_retry_attempts,
         )
 
         # Pass the GraphQL client to each module


### PR DESCRIPTION
Fixes #25.

## Summary
- add type hints to `MondayClient.__init__`
- keep the existing defaults and runtime behavior unchanged
- align the constructor typing with the already-typed `MondayGraphQL.__init__`

## Verification
- `python -m compileall src`
- `git diff --check`

This was implemented with Codex assistance, with the final diff reviewed before posting.