### PR TITLE
Include column metadata in column-value item fetch

### DIFF
--- a/src/monday_sdk/query_templates.py
+++ b/src/monday_sdk/query_templates.py
@@ -257,6 +257,10 @@ def get_item_query(board_id, column_id, value, limit, cursor=None):
                         id
                         text
                         value
+                        column {
+                            id
+                            title
+                        }
                     }                
                 }
             }


### PR DESCRIPTION
## Summary

- Add the missing `column { id title }` selection to `fetch_items_by_column_value` results.
- This matches the existing response model, where `ColumnValue.column` already supports column metadata.

## Verification

- `python -m venv .venv`
- `.\.venv\Scripts\python -m pip install -e .`
- `.\.venv\Scripts\python -m compileall src`
- generated `get_item_query(...)` locally and confirmed the query includes `column { id title }`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.