### PR TITLE
fix(items): derive the page size for the items(ids:) query from the ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="monday-api-python-sdk",  # Required
-    version="1.6.7",  # Required
+    version="1.6.8",  # Required
     description="A Python SDK for interacting with Monday's GraphQL API",  # Optional
     long_description=long_description,  # Optional
     long_description_content_type="text/markdown",  # Optional (see note above)

--- a/src/monday_sdk/constants.py
+++ b/src/monday_sdk/constants.py
@@ -9,3 +9,8 @@ DEFAULT_PAGE_LIMIT_ITEMS = 500
 DEFAULT_PAGE_LIMIT_UPDATES = 1000
 DEFAULT_PAGE_LIMIT_BOARDS = 50
 DEFAULT_PAGE_LIMIT_ACTIVITY_LOGS = 1000
+
+# The `items(ids: ...)` root query accepts at most 100 ids per request and
+# paginates its result with `limit` (which the API defaults to 25).
+MAX_ITEMS_BY_ID_PER_REQUEST = 100
+DEFAULT_PAGE_LIMIT_ITEMS_BY_ID = 100

--- a/src/monday_sdk/modules/items.py
+++ b/src/monday_sdk/modules/items.py
@@ -2,6 +2,7 @@ from typing import Union, Dict, Any, List, Optional
 import datetime
 import os
 
+from ..constants import MAX_ITEMS_BY_ID_PER_REQUEST
 from ..graphql_handler import MondayGraphQL
 from ..types import FileInput
 from ..query_templates import create_item_query, get_item_query, change_column_value_query, get_item_by_id_query, update_multiple_column_values_query, create_subitem_query, delete_item_query, archive_item_query, move_item_to_group_query, change_simple_column_value_query
@@ -73,12 +74,35 @@ class ItemModule:
         return self.client.execute(query)
 
     def fetch_items_by_id(self, ids: Union[str, int, List[Union[str, int]]]) -> List[Item]:
+        """
+        Fetches items by id in a single request.
+
+        The `items(ids: ...)` query paginates its result and the API defaults the page
+        size to 25, so the page size is derived from the number of ids requested. Without
+        it, asking for more than 25 ids returns only the 25 lowest ones - with no error
+        and no way for the caller to tell that anything was dropped.
+
+        The API accepts at most MAX_ITEMS_BY_ID_PER_REQUEST ids per request, which is also
+        the largest page it will return, so one request is always enough to cover the ids
+        asked for and there is nothing left to paginate through. Chunk larger id sets
+        caller-side.
+        """
         if isinstance(ids, (list, set)):
+            if len(ids) > MAX_ITEMS_BY_ID_PER_REQUEST:
+                raise ValueError(
+                    f"fetch_items_by_id accepts at most {MAX_ITEMS_BY_ID_PER_REQUEST} ids per request, got {len(ids)}"
+                )
+            if not ids:
+                return []
+            limit = len(ids)
             ids_str = ", ".join(map(str, ids))
             ids_str = f"[{ids_str}]"
         else:
+            # A bare id, or an id list the caller already formatted - we cannot count it,
+            # so ask for the largest page the API will give us.
+            limit = MAX_ITEMS_BY_ID_PER_REQUEST
             ids_str = str(ids)
-        query = get_item_by_id_query(ids_str)
+        query = get_item_by_id_query(ids_str, limit=limit)
         response = self.client.execute(query)
         return response.data.items
 

--- a/src/monday_sdk/query_templates.py
+++ b/src/monday_sdk/query_templates.py
@@ -2,6 +2,7 @@ import json
 from enum import Enum
 from typing import List, Union, Optional, Mapping, Any
 
+from .constants import DEFAULT_PAGE_LIMIT_ITEMS_BY_ID
 from .types import BoardKind, BoardState, BoardsOrderBy
 from .utils import monday_json_stringify, gather_params
 
@@ -267,13 +268,13 @@ def get_item_query(board_id, column_id, value, limit, cursor=None):
     return query
 
 
-def get_item_by_id_query(ids):
+def get_item_by_id_query(ids, limit: int = DEFAULT_PAGE_LIMIT_ITEMS_BY_ID, page: int = 1):
     query = """{
             complexity {
             query
             after
           }
-            items(ids: %s){
+            items(ids: %s, limit: %s, page: %s){
                 id
                 name
                 state
@@ -329,7 +330,9 @@ def get_item_by_id_query(ids):
                 }
             }
         }""" % (
-        ids
+        ids,
+        limit,
+        page,
     )
 
     return query


### PR DESCRIPTION
## The bug

`get_item_by_id_query` builds `items(ids: [...])` with no `limit`. That root query is **paginated** and the API **defaults the page size to 25**, so a caller asking for more than 25 ids gets back only the 25 lowest ids — no error, no warning, no way to tell anything was dropped.

This cost us real data. A Snowflake ingestion pipeline uses `fetch_items_by_id` to pick up archived, deleted and moved items in chunks of 99, and was losing **74 of every 99**. Archived items kept looking active downstream for weeks before BI noticed. The task was green the whole time.

## The fix

`fetch_items_by_id` derives the page size from the number of ids it was given, so the page always covers the request.

**The public signature is unchanged** — `fetch_items_by_id(ids)`, same as today. I deliberately did *not* expose `limit`, because a caller-supplied page size smaller than the id count reintroduces precisely this bug as an opt-in footgun. Deriving it makes truncation impossible by construction rather than dependent on picking a good default.

Also caps the request at **100 ids**, the API's real hard limit (101 returns `InvalidArgumentException` "exceeding the 100 limit"), instead of letting the API silently truncate.

### Why there's no pagination loop

Worth stating explicitly since the method returns a single page: the API caps `ids` at 100 and will return a page that large, so one request always covers the ids asked for — there is nothing left to paginate through. Larger id sets are chunked caller-side, which is what callers already do. The docstring records this reasoning, so if the id cap ever rises above the max page size it's visible that a loop becomes necessary.

## Verification

Run against a live board that lost data, using the query strings this code generates. Same 26 ids, page size the only variable:

| Request | Returned |
|---|---|
| 26 ids, `limit: 26` | **26/26**, all `archived` |
| 26 ids, no `limit` (current behaviour) | **25/26** — the 26th is dropped |
| 60 ids, `limit: 60` | **60/60**, all `archived` |
| 60 ids, `limit: 25, page: 2` | ids 26–50, disjoint from page 1 |

The item that falls off the 26-id request without `limit` is the exact item that was reported as still active in the warehouse. The `page: 2` row confirms the underlying paging always worked — it just was never being asked for.

Derived page size across edge cases, verified via a captured-query harness:

| Input | Rendered |
|---|---|
| 60 / 26 / 25 / 1 ids | `limit: 60` / `26` / `25` / `1` |
| 100 ids | `limit: 100` |
| bare `int` / `str`, or pre-formatted `"[1, 2, 3]"` | `limit: 100` — uncountable, so request the largest page |
| `set` of 30 | `limit: 30` |
| `[]` | short-circuits, no request issued |
| 101 ids | `ValueError` |

No test file: the repo has no tracked tests and no test CI, so I didn't invent a convention here. Happy to add one under `tests/` with a runner if you'd like it.

## Behaviour change to be aware of

Callers passing >25 ids **will start receiving items they were previously, silently, not getting**. That is the point of the fix, but it does change what comes back, so it's worth a minor version rather than a patch if you'd prefer — say the word and I'll adjust.

Two other calls worth your opinion:

1. **101 ids raises instead of auto-chunking.** A caller that previously sent 150 ids and got 25 back now gets a `ValueError`. I chose the loud failure and left chunking to the caller so request count and complexity cost stay visible, but auto-chunking internally is a defensible alternative.
2. **The version bump to 1.6.8 is in this commit.** Pull it out if releases are a separate commit in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
